### PR TITLE
fix: add static folder to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,7 @@ RUN poetry install --no-root
 
 COPY ./app /code/app
 
+COPY ./static /code/static
+
 
 CMD ["poetry", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
Resolves the `RuntimeError: Directory 'static' does not exist` on fly.io